### PR TITLE
Return the status code in the api error type.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 

--- a/src/bf/config.rs
+++ b/src/bf/config.rs
@@ -31,7 +31,7 @@ impl Environment {
             Development => "https://dev.blackfynn.io"
                 .parse::<Url>()
                 .unwrap(), // This should never fail
-            Production => "https://app.blackfynn.io"
+            Production => "https://api.blackfynn.io"
                 .parse::<Url>()
                 .unwrap() // This should never fail
         }

--- a/src/bf/error.rs
+++ b/src/bf/error.rs
@@ -14,7 +14,7 @@ use url;
 
 #[derive(Debug)]
 pub enum Error {
-    ApiError(String),
+    ApiError(hyper::StatusCode, String),
     HttpError(hyper::error::Error),
     InvalidUnicodePath(path::PathBuf),
     IoError(io::Error),
@@ -64,7 +64,7 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         use self::Error::*;
         match *self {
-            ApiError(_) => "api error",
+            ApiError(_, _) => "api error",
             HttpError(_) => "http error",
             InvalidUnicodePath(_) => "invalid unicode path",
             IoError(_) => "io error",
@@ -80,7 +80,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Error::*;
         match *self {
-            ApiError(ref message) => write!(f, "API error :: {}", message),
+            ApiError(status_code, ref message) => write!(f, "API error :: {} {}", status_code, message),
             HttpError(ref err) => write!(f, "HTTP error :: {}", err),
             InvalidUnicodePath(ref path) => write!(f, "Invalid unicode characters in path :: {:?}", path),
             IoError(ref err) => write!(f, "IO error :: {}", err),


### PR DESCRIPTION
Add status code to the `ApiError` type. This will allow the agent to return different cli responses for `unauthorized` vs. `not found` responses. Unfortunately, it appears the api returns 403 in cases where an object is not found.