### PR TITLE
Remove the Clone constraint from ProgressCallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.1.21"
+version = "0.1.22"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -26,7 +26,7 @@ use tokio;
 
 use super::{request, response};
 use bf;
-use bf::config::{ Config, Environment };
+use bf::config::{Config, Environment};
 use bf::model::{
     self, DatasetId, ImportId, OrganizationId, PackageId, SessionToken, TemporaryCredential, UserId,
 };

--- a/src/bf/config.rs
+++ b/src/bf/config.rs
@@ -8,8 +8,8 @@ use std::str::FromStr;
 
 use url::Url;
 
-use bf::model::S3ServerSideEncryption;
 use bf::error::{Error, ErrorKind};
+use bf::model::S3ServerSideEncryption;
 
 /// Defines the server environment the library is interacting with.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
@@ -59,7 +59,7 @@ impl FromStr for Environment {
             "dev" | "development" => Ok(Environment::Development),
             "prod" | "production" => Ok(Environment::Production),
             "local" => Ok(Environment::Local),
-            _ => Err(ErrorKind::EnvParseError(s.to_string()).into())
+            _ => Err(ErrorKind::EnvParseError(s.to_string()).into()),
         }
     }
 }


### PR DESCRIPTION
This commit remove the `Clone` constraint from `ProgressCallback` trait, changing it to:

`pub trait ProgressCallback: Send`

Without this, ProgressCallback would not be "object-safe", which simply
put, means it is implicitly sized to the Clone constraint and a Boxed
version of it like `Box<dyn ProgressCallback>` cannot be constructed.

This change places the constraint on associated arguments for functions
which accept a progress callback.