### PR TITLE
AP-438: Pass dataset integer id to upload preview endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Blackfynn Rust library.
 ## Usage
 ```
 [dependencies]
-blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.6.0" }
+blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.6.2" }
 ```
 
 ## License

--- a/src/bf/api/request/package.rs
+++ b/src/bf/api/request/package.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018 Blackfynn, Inc. All Rights Reserved.
 
-use bf::model::{DatasetId, PackageType, Property};
+use bf::model::{DatasetNodeId, PackageType, Property};
 
 #[derive(Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -8,14 +8,14 @@ pub struct Create {
     name: String,
     package_type: PackageType,
     properties: Vec<Property>,
-    dataset: DatasetId,
+    dataset: DatasetNodeId,
 }
 
 impl Create {
     pub fn new<P, Q>(name: P, package_type: PackageType, dataset: Q) -> Self
     where
         P: Into<String>,
-        Q: Into<DatasetId>,
+        Q: Into<DatasetNodeId>,
     {
         Self {
             name: name.into(),

--- a/src/bf/model/dataset.rs
+++ b/src/bf/model/dataset.rs
@@ -8,14 +8,14 @@ use bf::model;
 use chrono::{DateTime, Utc};
 use std::fmt;
 
-/// An identifier for a Blackfynn dataset.
+/// An node identifier for a Blackfynn dataset (ex. N:dataset:c905919f-56f5-43ae-9c2a-8d5d542c133b).
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct DatasetId(String);
+pub struct DatasetNodeId(String);
 
-impl DatasetId {
+impl DatasetNodeId {
     #[allow(dead_code)]
     pub fn new<S: Into<String>>(id: S) -> Self {
-        DatasetId(id.into())
+        DatasetNodeId(id.into())
     }
 
     /// Unwraps the value.
@@ -24,46 +24,94 @@ impl DatasetId {
     }
 }
 
-impl Borrow<String> for DatasetId {
+impl Borrow<String> for DatasetNodeId {
     fn borrow(&self) -> &String {
         &self.0
     }
 }
 
-impl Borrow<str> for DatasetId {
+impl Borrow<str> for DatasetNodeId {
     fn borrow(&self) -> &str {
         self.0.as_str()
     }
 }
 
-impl Deref for DatasetId {
+impl Deref for DatasetNodeId {
     type Target = String;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl From<DatasetId> for String {
-    fn from(id: DatasetId) -> Self {
+impl From<DatasetNodeId> for String {
+    fn from(id: DatasetNodeId) -> Self {
         id.0
     }
 }
 
-impl<'a> From<&'a DatasetId> for String {
-    fn from(id: &'a DatasetId) -> Self {
+impl<'a> From<&'a DatasetNodeId> for String {
+    fn from(id: &'a DatasetNodeId) -> Self {
         id.0.to_string()
     }
 }
 
-impl From<String> for DatasetId {
+impl From<String> for DatasetNodeId {
     fn from(id: String) -> Self {
         Self::new(id)
     }
 }
 
-impl<'a> From<&'a str> for DatasetId {
+impl<'a> From<&'a str> for DatasetNodeId {
     fn from(id: &'a str) -> Self {
         Self::new(String::from(id))
+    }
+}
+
+impl fmt::Display for DatasetNodeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// An integer identifier for a Blackfynn dataset
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct DatasetId(u32);
+
+impl DatasetId {
+    #[allow(dead_code)]
+    pub fn new(id: u32) -> Self {
+        DatasetId(id)
+    }
+
+    /// Unwraps the value.
+    #[allow(dead_code)]
+    pub fn take(self) -> u32 {
+        self.0
+    }
+}
+
+impl Deref for DatasetId {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<DatasetId> for u32 {
+    fn from(id: DatasetId) -> Self {
+        id.0
+    }
+}
+
+impl From<u32> for DatasetId {
+    fn from(id: u32) -> Self {
+        Self::new(id)
+    }
+}
+
+impl From<DatasetId> for String {
+    fn from(id: DatasetId) -> Self {
+        id.0.to_string()
     }
 }
 
@@ -87,7 +135,7 @@ pub enum DatasetStatus {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Dataset {
-    id: DatasetId,
+    id: DatasetNodeId,
     name: String,
     state: Option<model::PackageState>,
     description: Option<String>,
@@ -96,10 +144,11 @@ pub struct Dataset {
     status: DatasetStatus,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
+    int_id: DatasetId,
 }
 
 impl BFId for Dataset {
-    type Id = DatasetId;
+    type Id = DatasetNodeId;
     fn id(&self) -> &Self::Id {
         self.id()
     }
@@ -112,8 +161,12 @@ impl BFName for Dataset {
 }
 
 impl Dataset {
-    pub fn id(&self) -> &DatasetId {
+    pub fn id(&self) -> &DatasetNodeId {
         &self.id
+    }
+
+    pub fn int_id(&self) -> &DatasetId {
+        &self.int_id
     }
 
     pub fn name(&self) -> &String {

--- a/src/bf/model/mod.rs
+++ b/src/bf/model/mod.rs
@@ -22,7 +22,7 @@ pub use self::aws::{
     SecretKey,
 };
 pub use self::channel::Channel;
-pub use self::dataset::{Dataset, DatasetStatus, DatasetId};
+pub use self::dataset::{Dataset, DatasetId, DatasetNodeId, DatasetStatus};
 pub use self::file::File;
 pub use self::organization::{Organization, OrganizationId};
 pub use self::package::{Package, PackageId, PackageState, PackageType};

--- a/src/bf/model/package.rs
+++ b/src/bf/model/package.rs
@@ -155,7 +155,7 @@ impl PackageType {
 pub struct Package {
     id: PackageId,
     name: String,
-    dataset_id: model::DatasetId,
+    dataset_id: model::DatasetNodeId,
     package_state: Option<PackageState>,
     #[serde(deserialize_with = "PackageType::deserialize")]
     package_type: Option<PackageType>,
@@ -186,7 +186,7 @@ impl Package {
     }
 
     #[allow(dead_code)]
-    pub fn dataset_id(&self) -> &model::DatasetId {
+    pub fn dataset_id(&self) -> &model::DatasetNodeId {
         &self.dataset_id
     }
 

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -206,14 +206,15 @@ impl NormalizedPath {
         }
     }
 
+    #[allow(dead_code)]
     pub fn file_name(&self) -> &String {
         &self.file_name
     }
-
+    #[allow(dead_code)]
     pub fn destination_path(&self) -> Option<&String> {
         self.destination_path.as_ref()
     }
-
+    #[allow(dead_code)]
     pub fn metadata(&self) -> &fs::Metadata {
         &self.metadata
     }


### PR DESCRIPTION
This PR makes the following changes to the Rust agent:
- Renames the `DatasetId` model as `DatasetNodeId`
- Creates a new `DatasetId` model corresponding to the dataset integer id
- Passes the dataset integer id as a query parameter to the `upload/preview` endpoint on the upload-service.