### PR TITLE
Refactor to convert a empty list in to a None

### DIFF
--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -768,7 +768,7 @@ mod tests {
 
         match result {
             Err(err) => panic!("failed to get directory {:?}", err),
-            Ok(s3_file) => assert!(s3_file.file_path == Some(vec![])),
+            Ok(s3_file) => assert!(s3_file.file_path == None) 
         }
     }
 }

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -319,7 +319,18 @@ impl S3File {
                     })
                     .collect::<bf::Result<Vec<String>>>()
             })
-            .map_or(Ok(None), |maybe_dir| maybe_dir.map(|dir| Some(dir)))?;
+            .map_or(
+                Ok(None),
+                |maybe_dir| {
+                    maybe_dir.map(|dir| {
+                       if dir.is_empty() {
+                           None
+                       } else {
+                           Some(dir)
+                       }
+                    })
+                }
+            )?;
 
         // And the resulting metadata so we can pull the file size:
         let metadata = fs::metadata(file_path)?;


### PR DESCRIPTION
We are getting 400s back from upload service when we send empty lists for the filePath. The issue appears to be in circe when the object is deserialized