### PR TITLE
Add early returns for zero size parts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 

--- a/src/bf/api/client/progress.rs
+++ b/src/bf/api/client/progress.rs
@@ -95,7 +95,7 @@ impl ProgressUpdate {
         let bytes_sent = self.bytes_sent();
         let size = self.bytes_sent();
 
-        if size == 0 && bytes_sent == 0 {
+        if size == 0 {
             if self.part_number == 0 {
                 return 0.0;
             } else {

--- a/src/bf/api/client/progress.rs
+++ b/src/bf/api/client/progress.rs
@@ -92,7 +92,18 @@ impl ProgressUpdate {
 
     /// Returns the upload percentage completed.
     pub fn percent_done(&self) -> f32 {
-        (self.bytes_sent() as f32 / self.size() as f32) * 100.0
+        let bytes_sent = self.bytes_sent();
+        let size = self.bytes_sent();
+
+        if size == 0 && bytes_sent == 0 {
+            if self.part_number == 0 {
+                return 0.0;
+            } else {
+                return 100.0;
+            }
+        }
+
+        (bytes_sent as f32 / size as f32) * 100.0
     }
 
     /// Tests if the file completed uploading.

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -319,18 +319,9 @@ impl S3File {
                     })
                     .collect::<bf::Result<Vec<String>>>()
             })
-            .map_or(
-                Ok(None),
-                |maybe_dir| {
-                    maybe_dir.map(|dir| {
-                       if dir.is_empty() {
-                           None
-                       } else {
-                           Some(dir)
-                       }
-                    })
-                }
-            )?;
+            .map_or(Ok(None), |maybe_dir| {
+                maybe_dir.map(|dir| if dir.is_empty() { None } else { Some(dir) })
+            })?;
 
         // And the resulting metadata so we can pull the file size:
         let metadata = fs::metadata(file_path)?;
@@ -768,7 +759,7 @@ mod tests {
 
         match result {
             Err(err) => panic!("failed to get directory {:?}", err),
-            Ok(s3_file) => assert!(s3_file.file_path == None) 
+            Ok(s3_file) => assert!(s3_file.file_path == None),
         }
     }
 }


### PR DESCRIPTION
Currently we try to calculate percentage done as if all values for bytes_sent and for size were non zero. Instead we would like to take the nature of this edge case in to account when calculating percentage done