### PR TITLE
AP-465: Add new FileUpload enum to differentiate between upload modes

### DIFF
--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -713,8 +713,8 @@ impl Blackfynn {
     /// Generate a preview of the files to be uploaded.
     pub fn preview_upload_using_upload_service<P, Q>(
         &self,
-        organization_id: OrganizationId,
-        dataset_id: DatasetId,
+        organization_id: &OrganizationId,
+        dataset_id: &DatasetId,
         path: P,
         files: &[Q],
         append: bool,
@@ -747,6 +747,8 @@ impl Blackfynn {
             );
 
         let bf = self.clone();
+        let organization_id = organization_id.clone();
+        let dataset_id = dataset_id.clone();
 
         let post = s3_files
             .into_future()
@@ -1933,8 +1935,8 @@ pub mod tests {
                 })
                 .and_then(move |(bf, dataset_id, organization_id, dataset_int_id)| {
                     bf.preview_upload_using_upload_service(
-                        organization_id.clone(),
-                        dataset_int_id,
+                        &organization_id.clone(),
+                        &dataset_int_id,
                         (*TEST_DATA_DIR).to_string(),
                         &*TEST_FILES,
                         false,
@@ -2025,8 +2027,8 @@ pub mod tests {
                 })
                 .and_then(move |(bf, dataset_id, organization_id, dataset_int_id)| {
                     bf.preview_upload_using_upload_service(
-                        organization_id.clone(),
-                        dataset_int_id,
+                        &organization_id.clone(),
+                        &dataset_int_id,
                         (*MEDIUM_TEST_DATA_DIR).to_string(),
                         &*MEDIUM_TEST_FILES,
                         false,
@@ -2151,8 +2153,8 @@ pub mod tests {
                 })
                 .and_then(move |(bf, dataset_id, organization_id, dataset_int_id)| {
                     bf.preview_upload_using_upload_service(
-                        organization_id.clone(),
-                        dataset_int_id,
+                        &organization_id.clone(),
+                        &dataset_int_id,
                         (*MEDIUM_TEST_DATA_DIR).to_string(),
                         &*MEDIUM_TEST_FILES,
                         false,
@@ -2247,8 +2249,8 @@ pub mod tests {
                         .map(|filename| format!("medium/{}", filename))
                         .collect();
                     bf.preview_upload_using_upload_service(
-                        organization_id.clone(),
-                        dataset_int_id,
+                        &organization_id.clone(),
+                        &dataset_int_id,
                         (*MEDIUM_TEST_DATA_DIR).to_string(),
                         &*files_with_path,
                         false,

--- a/src/bf/error.rs
+++ b/src/bf/error.rs
@@ -24,6 +24,7 @@ error_chain! {
         Cancelled(futures::Canceled);
         HttpError(hyper::error::Error);
         IoError(io::Error);
+        StripPrefixError(path::StripPrefixError);
         JsonError(serde_json::Error);
         S3AbortMultipartUploadError(rusoto_s3::AbortMultipartUploadError);
         S3CreateMultipartUploadError(rusoto_s3::CreateMultipartUploadError);
@@ -50,6 +51,10 @@ error_chain! {
         InvalidUnicodePathError(p: path::PathBuf) {
             description("API: Invalid unicode characters in path")
             display("API: Invalid unicode characters in path :: {:?}", p)
+        }
+        NoPathParentError(p: path::PathBuf) {
+            description("Could not get the parent of path")
+            display("Could not get the parent of path :: {:?}", p)
         }
         NoOrganizationSetError {
             description("API: No organization set")

--- a/src/bf/model/mod.rs
+++ b/src/bf/model/mod.rs
@@ -29,5 +29,5 @@ pub use self::package::{Package, PackageId, PackageState, PackageType};
 pub use self::property::Property;
 pub use self::security::{TemporaryCredential, UploadCredential};
 pub use self::team::Team;
-pub use self::upload::{ImportId, ManifestEntry, PackagePreview, S3File};
+pub use self::upload::{ImportId, ManifestEntry, PackagePreview, S3File, FileUpload};
 pub use self::user::{User, UserId};

--- a/src/bf/model/mod.rs
+++ b/src/bf/model/mod.rs
@@ -29,5 +29,5 @@ pub use self::package::{Package, PackageId, PackageState, PackageType};
 pub use self::property::Property;
 pub use self::security::{TemporaryCredential, UploadCredential};
 pub use self::team::Team;
-pub use self::upload::{ImportId, ManifestEntry, PackagePreview, S3File, FileUpload};
+pub use self::upload::{FileUpload, ImportId, ManifestEntry, PackagePreview, S3File};
 pub use self::user::{User, UserId};

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Borrow;
 use std::fmt;
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::{cmp, fs};
 

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -203,6 +203,8 @@ impl FileUpload {
     /// # Example
     ///
     /// ```
+    /// use blackfynn::model::FileUpload;
+    ///
     /// let flat_upload = FileUpload::new_flat_directory_upload(
     ///   "/Users/matt/my_file.txt"
     /// );
@@ -243,6 +245,8 @@ impl FileUpload {
     /// # Example
     ///
     /// ```
+    /// use blackfynn::model::FileUpload;
+    ///
     /// let recursive_upload = FileUpload::new_recursive_directory_upload(
     ///   "/Users/matt/folder_to_recursivly_upload",                // base_path
     ///   "folder_to_recursivly_upload/nested_folder/my_file.txt",  // file_path

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -264,9 +264,9 @@ impl FileUpload {
 
         // the base path should actually be the parent of the given
         // base path in order to put all files into a collection
-        let base_path = base_path.parent().ok_or_else(|| {
-            bf::error::ErrorKind::NoPathParentError(base_path.to_path_buf())
-        })?;
+        let base_path = base_path
+            .parent()
+            .ok_or_else(|| bf::error::ErrorKind::NoPathParentError(base_path.to_path_buf()))?;
 
         // create a full file path in order to check that it is valid
         let file_path = base_path.join(file_path);


### PR DESCRIPTION
This is part 1 of https://blackfynn.atlassian.net/browse/AP-465: stop trying to use the `S3File` for our 2 upload "modes" (recursive vs non-recursive) and use different types to represent/derive the data that is required by these different modes.

For example, recursive uploads require a `base_path`, but this doesn't really make sense in the context of other upload modes.