### PR TITLE
AP-455: Add generic `get_dataset` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Blackfynn Rust library.
 ## Usage
 ```
 [dependencies]
-blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.7.0" }
+blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.8.0" }
 ```
 
 ## License

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -488,6 +488,18 @@ impl Blackfynn {
         }))
     }
 
+    /// Get a dataset by ID or by name.
+    pub fn get_dataset<N: Into<String>>(&self, id_or_name: N) -> bf::Future<response::Dataset> {
+        let id_or_name = id_or_name.into();
+        let id = DatasetNodeId::from(id_or_name.clone());
+        let name = id_or_name.clone();
+        let inner = self.clone();
+        into_future_trait(
+            self.get_dataset_by_id(id)
+                .or_else(move |_| inner.get_dataset_by_name(name)),
+        )
+    }
+
     /// Get the collaborators of the data set.
     pub fn get_dataset_collaborators(
         &self,
@@ -1332,6 +1344,34 @@ pub mod tests {
             into_future_trait(
                 bf.login(TEST_API_KEY, TEST_SECRET_KEY)
                     .and_then(move |_| bf.get_dataset_by_name(FIXTURE_DATASET_NAME)),
+            )
+        });
+
+        if ds.is_err() {
+            panic!("{}", ds.unwrap_err().display_chain().to_string());
+        }
+    }
+
+    #[test]
+    fn fetching_dataset_generic_works_with_name() {
+        let ds = run(&bf(), move |bf| {
+            into_future_trait(
+                bf.login(TEST_API_KEY, TEST_SECRET_KEY)
+                    .and_then(move |_| bf.get_dataset(FIXTURE_DATASET_NAME)),
+            )
+        });
+
+        if ds.is_err() {
+            panic!("{}", ds.unwrap_err().display_chain().to_string());
+        }
+    }
+
+    #[test]
+    fn fetching_dataset_generic_works_with_id() {
+        let ds = run(&bf(), move |bf| {
+            into_future_trait(
+                bf.login(TEST_API_KEY, TEST_SECRET_KEY)
+                    .and_then(move |_| bf.get_dataset(DatasetNodeId::new(FIXTURE_DATASET))),
             )
         });
 

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -493,11 +493,19 @@ impl Blackfynn {
         let id_or_name = id_or_name.into();
         let id = DatasetNodeId::from(id_or_name.clone());
         let name = id_or_name.clone();
-        let inner = self.clone();
-        into_future_trait(
-            self.get_dataset_by_id(id)
-                .or_else(move |_| inner.get_dataset_by_name(name)),
-        )
+
+        // Definitely not a dataset ID - only try to get by name
+        if !id_or_name.starts_with("N:dataset:") {
+            into_future_trait(self.get_dataset_by_name(name))
+
+        // Even if it looks like an ID it could still be a name - try both methods
+        } else {
+            let inner = self.clone();
+            into_future_trait(
+                self.get_dataset_by_id(id)
+                    .or_else(move |_| inner.get_dataset_by_name(name)),
+            )
+        }
     }
 
     /// Get the collaborators of the data set.


### PR DESCRIPTION
Add a `get_dataset` method that tries to get a dataset by name or by ID.

To enable https://github.com/Blackfynn/agent/pull/89