### PR TITLE
Make the Blackfynn library more idiomatic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Blackfynn Rust library.
 ## Usage
 ```
 [dependencies]
-blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.8.0" }
+blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.9.0" }
 ```
 
 ## License

--- a/src/bf/api/request/package.rs
+++ b/src/bf/api/request/package.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2018 Blackfynn, Inc. All Rights Reserved.
 
-use bf::model::{DatasetNodeId, PackageType, Property};
+use bf::model::{DatasetNodeId, Property};
+
+pub use bf::model::PackageType;
 
 #[derive(Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -214,7 +214,10 @@ impl FileUpload {
     ///   UploadId::from(1), "/Users/matt/my_file.txt"
     /// );
     /// ```
-    pub fn new_non_recursive_upload<P: AsRef<Path>>(id: UploadId, absolute_path: P) -> bf::Result<Self> {
+    pub fn new_non_recursive_upload<P: AsRef<Path>>(
+        id: UploadId,
+        absolute_path: P,
+    ) -> bf::Result<Self> {
         let absolute_path = absolute_path.as_ref();
 
         let absolute_path = if absolute_path.is_absolute() {
@@ -307,7 +310,10 @@ impl FileUpload {
                 base_path,
                 relative_path,
             } => base_path.join(relative_path.to_path_buf()),
-            FileUpload::NonRecursiveUpload { id: _, absolute_path } => absolute_path.to_path_buf(),
+            FileUpload::NonRecursiveUpload {
+                id: _,
+                absolute_path,
+            } => absolute_path.to_path_buf(),
         }
     }
 
@@ -454,7 +460,8 @@ impl S3File {
         let metadata = fs::metadata(file_path.clone())?;
         let file_size = metadata.len();
 
-        let file_name = file_path.file_name()
+        let file_name = file_path
+            .file_name()
             .and_then(|name| name.to_str())
             .ok_or_else(|| bf::ErrorKind::InvalidUnicodePathError(file_path.clone()))?;
 
@@ -464,7 +471,7 @@ impl S3File {
             size: file_size,
             chunked_upload: None,
             multipart_upload_id: None,
-            file_path: destination_path
+            file_path: destination_path,
         })
     }
 


### PR DESCRIPTION
Makes the following methods on the Blackfynn struct more idiomatic by allowing them to take arguments directly, rather than being passed a create/upload payload struct:

- create_package
- update_package
- create_dataset
- update_dataset