### PR TITLE
AP-670: Fix percent done calculation to use the size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Blackfynn Rust library.
 ## Usage
 ```
 [dependencies]
-blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.10.0" }
+blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.10.1" }
 ```
 
 ## License

--- a/src/bf/api/client/progress.rs
+++ b/src/bf/api/client/progress.rs
@@ -92,6 +92,11 @@ impl ProgressUpdate {
 
     /// Returns the upload percentage completed.
     pub fn percent_done(&self) -> f32 {
+
+        // when uploading an empty (0 byte) file, we send up a single
+        // part with no data. Since we can't rely on `bytes_sent` to
+        // track progress on an empty file, we instead look at the
+        // part number.
         if self.size == 0 {
             if self.part_number == 0 {
                 return 0.0;

--- a/src/bf/api/client/progress.rs
+++ b/src/bf/api/client/progress.rs
@@ -92,10 +92,7 @@ impl ProgressUpdate {
 
     /// Returns the upload percentage completed.
     pub fn percent_done(&self) -> f32 {
-        let bytes_sent = self.bytes_sent();
-        let size = self.bytes_sent();
-
-        if size == 0 {
+        if self.size == 0 {
             if self.part_number == 0 {
                 return 0.0;
             } else {
@@ -103,7 +100,7 @@ impl ProgressUpdate {
             }
         }
 
-        (bytes_sent as f32 / size as f32) * 100.0
+        (self.bytes_sent as f32 / self.size as f32) * 100.0
     }
 
     /// Tests if the file completed uploading.


### PR DESCRIPTION
Currently the `percent_done` function will always either return '0' or '100' because we're treating `bytes_sent` as the size. We should use the actual size to calculate a true percentage.