### PR TITLE
Replace error-chain with failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 [dependencies]
 chrono = { version = "^0.4", features = ["serde"] }
 sha2 = "^0.8"
-error-chain = "^0.12"
+failure = "^0.1"
+failure_derive = "^0.1"
 futures = "^0.1"
 hyper = "^0.12"
 hyper-tls = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 

--- a/src/bf/api/client/s3.rs
+++ b/src/bf/api/client/s3.rs
@@ -4,24 +4,23 @@
 
 use std::cell::Cell;
 use std::collections::hash_map;
-use std::iter;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
+use std::{iter, result};
 
-use futures::*;
+use futures::{Future as _Future, Stream as _Stream, *};
 
 use rusoto_core::request::HttpClient;
 use rusoto_credential::StaticProvider;
 use rusoto_s3::{self, S3Client, S3};
 
-use bf;
-use bf::model;
 use bf::model::{
     AccessKey, ImportId, S3Bucket, S3File, S3Key, S3ServerSideEncryption, S3UploadId, SecretKey,
     SessionToken, UploadCredential,
 };
 use bf::util::futures::{into_future_trait, into_stream_trait};
+use bf::{model, Error, ErrorKind, Future, Result, Stream};
 
 use super::progress::{NoProgress, ProgressCallback, ProgressUpdate};
 
@@ -37,14 +36,14 @@ fn create_s3_client(
     access_key: AccessKey,
     secret_key: SecretKey,
     session_token: SessionToken,
-) -> bf::Result<S3Client> {
+) -> Result<S3Client> {
     let credentials_provider = StaticProvider::new(
         access_key.into(),
         secret_key.into(),
         Some(Into::<String>::into(session_token)),
         None,
     );
-    let client = HttpClient::new().map_err(|e| bf::Error::with_chain(e, "s3::create_s3_client"))?;
+    let client = HttpClient::new()?;
     let region = Default::default();
     Ok(S3Client::new_with(client, credentials_provider, region))
 }
@@ -52,7 +51,7 @@ fn create_s3_client(
 /// The possible outcomes of a multipart upload.
 #[derive(Debug)]
 pub enum MultipartUploadResult {
-    Abort(bf::error::Error, rusoto_s3::AbortMultipartUploadOutput),
+    Abort(Error, rusoto_s3::AbortMultipartUploadOutput),
     Complete(ImportId, rusoto_s3::CompleteMultipartUploadOutput),
 }
 
@@ -184,7 +183,7 @@ where
     }
 
     /// Uploads a file's parts to an AWS S3 bucket.
-    pub fn upload_parts<P>(&self, path: P) -> bf::Stream<rusoto_s3::CompletedPart>
+    pub fn upload_parts<P>(&self, path: P) -> Stream<rusoto_s3::CompletedPart>
     where
         P: 'static + AsRef<Path>,
     {
@@ -238,8 +237,8 @@ where
                     let f = future::lazy(move || {
                         s3_client
                             .upload_part(request)
+                            .map_err(Into::into)
                             .map(move |output| (output, part_number))
-                            .map_err(|e| bf::Error::with_chain(e, "bf:api:s3:upload parts"))
                             .and_then(move |(part_output, part_number)| {
                                 // Update the sent byte count and signal the fact.
                                 // If there's a send error, ignore it:
@@ -279,14 +278,12 @@ where
 
             into_stream_trait(f)
         } else {
-            into_stream_trait(stream::once(Err(
-                bf::error::ErrorKind::S3MissingUploadIdError.into(),
-            )))
+            into_stream_trait(stream::once(Err(ErrorKind::S3MissingUploadId.into())))
         }
     }
 
     /// Aborts a multipart upload.
-    pub fn abort(self) -> bf::Future<rusoto_s3::AbortMultipartUploadOutput> {
+    pub fn abort(self) -> Future<rusoto_s3::AbortMultipartUploadOutput> {
         if let Some(upload_id) = self.upload_id.clone() {
             let request = rusoto_s3::AbortMultipartUploadRequest {
                 upload_id: upload_id.into(),
@@ -297,13 +294,11 @@ where
             let f = self
                 .s3_client
                 .abort_multipart_upload(request)
-                .map_err(|e| bf::Error::with_chain(e, "bf:api:s3:multipart upload abort"));
+                .map_err(Into::into);
 
             into_future_trait(f)
         } else {
-            into_future_trait(
-                Err(bf::error::ErrorKind::S3MissingUploadIdError.into()).into_future(),
-            )
+            into_future_trait(Err(ErrorKind::S3MissingUploadId.into()).into_future())
         }
     }
 
@@ -311,7 +306,7 @@ where
     pub fn complete(
         &self,
         mut parts: Vec<rusoto_s3::CompletedPart>,
-    ) -> bf::Future<rusoto_s3::CompleteMultipartUploadOutput> {
+    ) -> Future<rusoto_s3::CompleteMultipartUploadOutput> {
         if let Some(upload_id) = self.upload_id.clone() {
             // Parts must be sorted according to part_number, otherwise
             // S3 will reject the request:
@@ -328,13 +323,11 @@ where
             let f = self
                 .s3_client
                 .complete_multipart_upload(request)
-                .map_err(|e| bf::Error::with_chain(e, "bf:api:s3:multipart upload complete"));
+                .map_err(Into::into);
 
             into_future_trait(f)
         } else {
-            into_future_trait(
-                Err(bf::error::ErrorKind::S3MissingUploadIdError.into()).into_future(),
-            )
+            into_future_trait(Err(ErrorKind::S3MissingUploadId.into()).into_future())
         }
     }
 }
@@ -418,7 +411,7 @@ impl S3Uploader {
         access_key: AccessKey,
         secret_key: SecretKey,
         session_token: SessionToken,
-    ) -> bf::Result<Self> {
+    ) -> Result<Self> {
         let (tx_progress, rx_progress) = channel::<ProgressUpdate>();
         let s3_client = create_s3_client(access_key, secret_key, session_token)?;
         Ok(Self {
@@ -431,7 +424,7 @@ impl S3Uploader {
     }
 
     /// Returns a file uploade progress poller.
-    pub fn progress(&mut self) -> Result<UploadProgress, ()> {
+    pub fn progress(&mut self) -> result::Result<UploadProgress, ()> {
         if let Some(rx_progress) = self.rx_progress.take() {
             Ok(UploadProgress::new(rx_progress))
         } else {
@@ -452,7 +445,7 @@ impl S3Uploader {
         files: Vec<S3File>,
         import_id: ImportId,
         credentials: UploadCredential,
-    ) -> bf::Stream<ImportId>
+    ) -> Stream<ImportId>
     where
         P: 'static + AsRef<Path>,
     {
@@ -469,7 +462,7 @@ impl S3Uploader {
         import_id: ImportId,
         credentials: UploadCredential,
         cb: C,
-    ) -> bf::Stream<ImportId>
+    ) -> Stream<ImportId>
     where
         C: 'static + ProgressCallback + Clone,
         P: 'static + AsRef<Path>,
@@ -509,7 +502,7 @@ impl S3Uploader {
         import_id: ImportId,
         credentials: &UploadCredential,
         cb: C,
-    ) -> bf::Future<ImportId>
+    ) -> Future<ImportId>
     where
         C: 'static + ProgressCallback + Clone,
         P: 'static + AsRef<Path>,
@@ -539,9 +532,7 @@ impl S3Uploader {
                     server_side_encryption: Some(s3_server_side_encryption),
                     ..Default::default()
                 };
-                s3_client
-                    .put_object(request)
-                    .map_err(|e| bf::Error::with_chain(e, "bf:api:s3:put object"))
+                s3_client.put_object(request).map_err(Into::into)
             })
             .and_then(move |_| {
                 let update =
@@ -563,7 +554,7 @@ impl S3Uploader {
         import_id: ImportId,
         credentials: UploadCredential,
         cb: C,
-    ) -> bf::Future<ImportId>
+    ) -> Future<ImportId>
     where
         C: 'static + ProgressCallback + Clone,
         P: 'static + AsRef<Path>,
@@ -579,7 +570,7 @@ impl S3Uploader {
 
         let f = stream::futures_unordered(fs)
             .into_future()
-            .map_err(|(e, _)| bf::Error::with_chain(e, "bf:api:s3:put objects"))
+            .map_err(|(err, _)| err)
             .and_then(|_| Ok(ret_import_id));
 
         into_future_trait(f)
@@ -593,7 +584,7 @@ impl S3Uploader {
         files: &[S3File],
         import_id: ImportId,
         credentials: UploadCredential,
-    ) -> bf::Future<ImportId>
+    ) -> Future<ImportId>
     where
         P: 'static + AsRef<Path>,
     {
@@ -607,7 +598,7 @@ impl S3Uploader {
         import_id: ImportId,
         credentials: &UploadCredential,
         cb: C,
-    ) -> bf::Future<MultipartUploadFile<C>>
+    ) -> Future<MultipartUploadFile<C>>
     where
         C: 'static + ProgressCallback + Clone,
     {
@@ -649,7 +640,7 @@ impl S3Uploader {
                     cb,
                 ))
             })
-            .map_err(|e| bf::Error::with_chain(e, "bf:api:s3:begin multipart upload"));
+            .map_err(Into::into);
 
         into_future_trait(f)
     }
@@ -662,7 +653,7 @@ impl S3Uploader {
         import_id: ImportId,
         credentials: &UploadCredential,
         cb: C,
-    ) -> bf::Future<MultipartUploadResult>
+    ) -> Future<MultipartUploadResult>
     where
         C: 'static + ProgressCallback + Clone,
         P: 'static + Send + AsRef<Path>,
@@ -708,7 +699,7 @@ impl S3Uploader {
         import_id: ImportId,
         credentials: UploadCredential,
         cb: C,
-    ) -> bf::Stream<MultipartUploadResult>
+    ) -> Stream<MultipartUploadResult>
     where
         C: 'static + ProgressCallback + Clone,
         P: 'static + AsRef<Path>,
@@ -736,7 +727,7 @@ impl S3Uploader {
         files: &Vec<S3File>,
         import_id: ImportId,
         credentials: UploadCredential,
-    ) -> bf::Stream<MultipartUploadResult>
+    ) -> Stream<MultipartUploadResult>
     where
         P: 'static + AsRef<Path>,
     {

--- a/src/bf/config.rs
+++ b/src/bf/config.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use url::Url;
 
-use bf::error::{Error, ErrorKind};
+use bf::error::Error;
 use bf::model::S3ServerSideEncryption;
 
 /// Defines the server environment the library is interacting with.
@@ -59,7 +59,7 @@ impl FromStr for Environment {
             "dev" | "development" => Ok(Environment::Development),
             "prod" | "production" => Ok(Environment::Production),
             "local" => Ok(Environment::Local),
-            _ => Err(ErrorKind::EnvParseError(s.to_string()).into()),
+            _ => Err(Error::env_parse_error(s)),
         }
     }
 }

--- a/src/bf/error.rs
+++ b/src/bf/error.rs
@@ -1,68 +1,269 @@
 // Copyright (c) 2018 Blackfynn, Inc. All Rights Reserved.
 
 //! Errors specific to the Blackfynn platform.
-use std::{io, path};
+use std::path::PathBuf;
+use std::{fmt, io, result};
 
-use futures;
+use failure::{Backtrace, Context, Fail};
 
-use hyper;
+/// Type alias for handling errors throughout the agent
+pub type Result<T> = result::Result<T, Error>;
 
-use rusoto_core;
+/// An error that can occur while interacting with the agent
+#[derive(Debug)]
+pub struct Error {
+    ctx: Context<ErrorKind>,
+}
 
-use rusoto_s3;
-
-use serde_json;
-
-use url;
-
-error_chain! {
-    types {
-        Error, ErrorKind, ResultExt, Result;
+impl Error {
+    /// Return the kind of this error.
+    pub fn kind(&self) -> &ErrorKind {
+        self.ctx.get_context()
     }
 
-    foreign_links {
-        Cancelled(futures::Canceled);
-        HttpError(hyper::error::Error);
-        IoError(io::Error);
-        StripPrefixError(path::StripPrefixError);
-        JsonError(serde_json::Error);
-        S3AbortMultipartUploadError(rusoto_s3::AbortMultipartUploadError);
-        S3CreateMultipartUploadError(rusoto_s3::CreateMultipartUploadError);
-        S3CompleteMultipartUploadError(rusoto_s3::CompleteMultipartUploadError);
-        S3PutObjectError(rusoto_s3::PutObjectError);
-        S3UploadPartError(rusoto_s3::UploadPartError);
-        TlsError(rusoto_core::request::TlsError);
-        UrlParseError(url::ParseError);
+    pub fn api_error<S: Into<String>>(status_code: hyper::StatusCode, message: S) -> Error {
+        ErrorKind::ApiError {
+            status_code,
+            message: message.into(),
+        }
+        .into()
     }
 
-    errors {
-        ApiError(status_code: hyper::StatusCode, message: String) {
-            description("API error")
-            display("API error :: {} {}", status_code, message)
+    pub fn upload_error<S: Into<String>>(message: S) -> Error {
+        ErrorKind::UploadError {
+            message: message.into(),
         }
-        UploadError(message: String) {
-            description("Upload error")
-            display("Upload error :: {}", message)
+        .into()
+    }
+
+    pub fn invalid_dataset_name<S: Into<String>>(name: S) -> Error {
+        ErrorKind::InvalidDatasetName { name: name.into() }.into()
+    }
+
+    pub fn invalid_arguments<S: Into<String>>(message: S) -> Error {
+        ErrorKind::InvalidArguments {
+            message: message.into(),
         }
-        EnvParseError(s: String) {
-            description("API: Invalid environment string")
-            display("API: Invalid environment string :: {}", s)
+        .into()
+    }
+
+    pub fn env_parse_error<S: Into<String>>(value: S) -> Error {
+        ErrorKind::EnvParseError {
+            value: value.into(),
         }
-        InvalidUnicodePathError(p: path::PathBuf) {
-            description("API: Invalid unicode characters in path")
-            display("API: Invalid unicode characters in path :: {:?}", p)
-        }
-        NoPathParentError(p: path::PathBuf) {
-            description("Could not get the parent of path")
-            display("Could not get the parent of path :: {:?}", p)
-        }
-        NoOrganizationSetError {
-            description("API: No organization set")
-            display("API: No organization set")
-        }
-        S3MissingUploadIdError {
-            description("S3: missing upload ID")
-            display("S3: missing upload ID")
-        }
+        .into()
+    }
+
+    pub fn no_path_parent(path: PathBuf) -> Error {
+        ErrorKind::NoPathParent { path }.into()
+    }
+
+    pub fn path_does_not_exist(path: PathBuf) -> Error {
+        ErrorKind::PathDoesNotExist { path }.into()
+    }
+
+    pub fn path_is_not_a_file(path: PathBuf) -> Error {
+        ErrorKind::PathIsNotAFile { path }.into()
+    }
+
+    pub fn could_not_get_filename(path: PathBuf) -> Error {
+        ErrorKind::CouldNotGetFilename { path }.into()
+    }
+
+    pub fn path_is_not_a_directory(path: PathBuf) -> Error {
+        ErrorKind::PathIsNotADirectory { path }.into()
+    }
+
+    pub fn invalid_unicode_path(path: PathBuf) -> Error {
+        ErrorKind::InvalidUnicodePath { path }.into()
+    }
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&Fail> {
+        self.ctx.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.ctx.backtrace()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.ctx.fmt(f)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Fail)]
+pub enum ErrorKind {
+    #[fail(display = "api error: {} {}", status_code, message)]
+    ApiError {
+        status_code: hyper::StatusCode,
+        message: String,
+    },
+
+    #[fail(display = "couldn't find dataset: \"{}\"", name)]
+    InvalidDatasetName { name: String },
+
+    #[fail(display = "upload error: {}", message)]
+    UploadError { message: String },
+
+    #[fail(display = "invalid environment string: {}", value)]
+    EnvParseError { value: String },
+
+    #[fail(display = "invalid unicode characters in path: {:?}", path)]
+    InvalidUnicodePath { path: PathBuf },
+
+    #[fail(display = "{}", message)]
+    InvalidArguments { message: String },
+
+    #[fail(display = "could not get path parent: {:?}", path)]
+    NoPathParent { path: PathBuf },
+
+    #[fail(display = "path does not exist: {:?}", path)]
+    PathDoesNotExist { path: PathBuf },
+
+    #[fail(display = "path is not a file: {:?}", path)]
+    PathIsNotAFile { path: PathBuf },
+
+    #[fail(display = "couldn't get filename from path: {:?}", path)]
+    CouldNotGetFilename { path: PathBuf },
+
+    #[fail(display = "path is not a directory: {:?}", path)]
+    PathIsNotADirectory { path: PathBuf },
+
+    #[fail(display = "no organization set")]
+    NoOrganizationSet,
+
+    #[fail(display = "retries exceeded")]
+    RetriesExceeded,
+
+    #[fail(display = "missing upload id")]
+    S3MissingUploadId,
+
+    #[fail(display = "io error: {}", error)]
+    IoError { error: String },
+
+    #[fail(display = "strip prefix error: {}", error)]
+    StripPrefixError { error: String },
+
+    #[fail(display = "hyper error: {}", error)]
+    HyperError { error: String },
+
+    #[fail(display = "tokio error: {}", error)]
+    TokioError { error: String },
+
+    #[fail(display = "rusoto error: {}", error)]
+    RusotoError { error: String },
+
+    #[fail(display = "json serialization error: {}", error)]
+    SerdeJsonError { error: String },
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error::from(Context::new(kind))
+    }
+}
+impl From<Context<ErrorKind>> for Error {
+    fn from(ctx: Context<ErrorKind>) -> Error {
+        Error { ctx }
+    }
+}
+
+/// map from StripPrefixError errors
+impl From<std::path::StripPrefixError> for Error {
+    fn from(error: std::path::StripPrefixError) -> Error {
+        Error::from(Context::new(ErrorKind::StripPrefixError {
+            error: error.to_string(),
+        }))
+    }
+}
+
+/// map from io errors
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Error {
+        Error::from(Context::new(ErrorKind::IoError {
+            error: error.to_string(),
+        }))
+    }
+}
+
+/// map from rusoto errors
+impl From<rusoto_core::request::TlsError> for Error {
+    fn from(error: rusoto_core::request::TlsError) -> Error {
+        Error::from(Context::new(ErrorKind::RusotoError {
+            error: error.to_string(),
+        }))
+    }
+}
+impl From<rusoto_s3::UploadPartError> for Error {
+    fn from(error: rusoto_s3::UploadPartError) -> Error {
+        Error::from(Context::new(ErrorKind::RusotoError {
+            error: error.to_string(),
+        }))
+    }
+}
+impl From<rusoto_s3::AbortMultipartUploadError> for Error {
+    fn from(error: rusoto_s3::AbortMultipartUploadError) -> Error {
+        Error::from(Context::new(ErrorKind::RusotoError {
+            error: error.to_string(),
+        }))
+    }
+}
+impl From<rusoto_s3::CompleteMultipartUploadError> for Error {
+    fn from(error: rusoto_s3::CompleteMultipartUploadError) -> Error {
+        Error::from(Context::new(ErrorKind::RusotoError {
+            error: error.to_string(),
+        }))
+    }
+}
+impl From<rusoto_s3::PutObjectError> for Error {
+    fn from(error: rusoto_s3::PutObjectError) -> Error {
+        Error::from(Context::new(ErrorKind::RusotoError {
+            error: error.to_string(),
+        }))
+    }
+}
+impl From<rusoto_s3::CreateMultipartUploadError> for Error {
+    fn from(error: rusoto_s3::CreateMultipartUploadError) -> Error {
+        Error::from(Context::new(ErrorKind::RusotoError {
+            error: error.to_string(),
+        }))
+    }
+}
+
+/// map from serde_json errors
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Error {
+        Error::from(Context::new(ErrorKind::SerdeJsonError {
+            error: error.to_string(),
+        }))
+    }
+}
+
+/// map from tokio errors
+impl From<tokio::timer::Error> for Error {
+    fn from(error: tokio::timer::Error) -> Error {
+        Error::from(Context::new(ErrorKind::TokioError {
+            error: error.to_string(),
+        }))
+    }
+}
+
+/// map from hyper errors
+impl From<hyper::Error> for Error {
+    fn from(error: hyper::Error) -> Error {
+        Error::from(Context::new(ErrorKind::HyperError {
+            error: error.to_string(),
+        }))
+    }
+}
+impl From<hyper::http::uri::InvalidUri> for Error {
+    fn from(error: hyper::http::uri::InvalidUri) -> Error {
+        Error::from(Context::new(ErrorKind::HyperError {
+            error: error.to_string(),
+        }))
     }
 }

--- a/src/bf/mod.rs
+++ b/src/bf/mod.rs
@@ -12,4 +12,4 @@ mod util;
 // Re-export
 pub use bf::api::Blackfynn;
 pub use bf::config::{Config, Environment};
-pub use bf::types::{Error, ErrorKind, Future, Result, ResultExt, Stream};
+pub use bf::types::{Error, ErrorKind, Future, Result, Stream};

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -1,15 +1,14 @@
 // Copyright (c) 2018 Blackfynn, Inc. All Rights Reserved.
 
 use std::borrow::Borrow;
-use std::fmt;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
-use std::{cmp, fs};
+use std::{cmp, fmt, fs, result};
 
 use futures::*;
 
 use bf::util::futures::{into_future_trait, into_stream_trait};
-use bf::{self, model};
+use bf::{model, Error, Future, Result, Stream};
 
 /// An identifier returned by the Blackfynn platform used to group
 /// a collection of files together for uploading.
@@ -117,7 +116,7 @@ impl S3FileChunk {
         file_size: u64,
         chunk_size: u64,
         index: u64,
-    ) -> bf::Result<Self> {
+    ) -> Result<Self> {
         let handle = fs::File::open(path)?;
         Ok(Self {
             handle,
@@ -127,7 +126,7 @@ impl S3FileChunk {
         })
     }
 
-    pub fn read(&mut self) -> bf::Result<Vec<u8>> {
+    pub fn read(&mut self) -> Result<Vec<u8>> {
         let offset = self.chunk_size * self.index;
         assert!(offset <= self.file_size);
         let read_amount = self.file_size - offset;
@@ -217,7 +216,7 @@ impl FileUpload {
     pub fn new_non_recursive_upload<P: AsRef<Path>>(
         id: UploadId,
         absolute_path: P,
-    ) -> bf::Result<Self> {
+    ) -> Result<Self> {
         let absolute_path = absolute_path.as_ref();
 
         let absolute_path = if absolute_path.is_absolute() {
@@ -226,14 +225,13 @@ impl FileUpload {
             absolute_path.canonicalize()?
         };
 
-        ensure!(
-            absolute_path.exists(),
-            format!("File does not exist: {:?}", absolute_path)
-        );
-        ensure!(
-            absolute_path.is_file(),
-            format!("File is not a regular file: {:?}", absolute_path)
-        );
+        if !absolute_path.exists() {
+            return Err(Error::path_does_not_exist(absolute_path));
+        }
+
+        if !absolute_path.is_file() {
+            return Err(Error::path_is_not_a_file(absolute_path));
+        }
 
         Ok(FileUpload::NonRecursiveUpload {
             id,
@@ -269,27 +267,27 @@ impl FileUpload {
         id: UploadId,
         base_path: P,
         file_path: Q,
-    ) -> bf::Result<Self> {
+    ) -> Result<Self> {
         let base_path = base_path.as_ref().canonicalize()?;
-        ensure!(
-            base_path.is_dir(),
-            format!("Not a directory: {:?}", base_path)
-        );
+        if !base_path.is_dir() {
+            return Err(Error::path_is_not_a_directory(base_path));
+        }
 
         // the base path should actually be the parent of the given
         // base path in order to put all files into a collection
         let base_path = base_path
             .parent()
-            .ok_or_else(|| bf::error::ErrorKind::NoPathParentError(base_path.to_path_buf()))?;
+            .ok_or_else(|| Error::no_path_parent(base_path.to_path_buf()))?;
 
         // create a full file path in order to check that it is valid
         let file_path = base_path.join(file_path);
 
-        ensure!(
-            base_path.is_dir(),
-            format!("Not a directory: {:?}", base_path)
-        );
-        ensure!(file_path.is_file(), format!("Not a file: {:?}", file_path));
+        if !base_path.is_dir() {
+            return Err(Error::path_is_not_a_directory(base_path.to_path_buf()));
+        }
+        if !file_path.is_file() {
+            return Err(Error::path_is_not_a_file(file_path));
+        }
 
         // strip the base_path from the file_path to make it relative again
         let file_path = file_path.strip_prefix(&base_path)?;
@@ -327,18 +325,18 @@ impl FileUpload {
 
     /// Get the name of the file that is represented by this
     /// FileUpload object
-    fn file_name(&self) -> bf::Result<String> {
+    fn file_name(&self) -> Result<String> {
         let absolute_path = self.absolute_file_path();
         absolute_path
             .file_name()
             .and_then(|file_name| file_name.to_str())
             .map(|file_name| file_name.to_string())
-            .ok_or_else(|| format!("Could not get filename: {:?}", absolute_path).into())
+            .ok_or_else(|| Error::could_not_get_filename(absolute_path))
     }
 
     /// Get the size of the file that is represented by this
     /// FileUpload object
-    fn file_size(&self) -> bf::Result<u64> {
+    fn file_size(&self) -> Result<u64> {
         let metadata = fs::metadata(self.absolute_file_path())?;
         Ok(metadata.len())
     }
@@ -351,14 +349,14 @@ impl FileUpload {
     /// have `None` as their destionation path, recursive uploads will
     /// have all elements of the local `file_path` starting at the
     /// `base_path`.
-    fn destination_path(&self) -> bf::Result<Option<Vec<String>>> {
+    fn destination_path(&self) -> Result<Option<Vec<String>>> {
         match self {
             FileUpload::RecursiveUpload { base_path, .. } => {
                 let absolute_path = self.absolute_file_path();
 
-                let destination_path = absolute_path.parent().ok_or_else(|| {
-                    bf::error::ErrorKind::NoPathParentError(absolute_path.to_path_buf())
-                })?;
+                let destination_path = absolute_path
+                    .parent()
+                    .ok_or_else(|| Error::no_path_parent(absolute_path.to_path_buf()))?;
                 let destination_path = destination_path.strip_prefix(base_path)?;
                 let destination_path = destination_path
                     .to_path_buf()
@@ -368,13 +366,10 @@ impl FileUpload {
                             .to_str()
                             .map(|dir| dir.to_string())
                             .ok_or_else(|| {
-                                bf::error::ErrorKind::InvalidUnicodePathError(
-                                    destination_path.to_path_buf(),
-                                )
-                                .into()
+                                Error::invalid_unicode_path(destination_path.to_path_buf()).into()
                             })
                     })
-                    .collect::<bf::Result<Vec<String>>>()?;
+                    .collect::<Result<Vec<String>>>()?;
                 if destination_path.is_empty() {
                     Ok(None)
                 } else {
@@ -386,7 +381,7 @@ impl FileUpload {
     }
 
     /// Transform this `FileUpload` object into an `S3File`
-    pub fn to_s3_file(&self) -> bf::Result<S3File> {
+    pub fn to_s3_file(&self) -> Result<S3File> {
         let file_size = self.file_size()?;
         let file_name = self.file_name()?;
         let destination_path = self.destination_path()?;
@@ -420,7 +415,7 @@ fn file_chunks<P: AsRef<Path>>(
     from_path: P,
     file_size: u64,
     chunk_size: u64,
-) -> bf::Result<Vec<S3FileChunk>> {
+) -> Result<Vec<S3FileChunk>> {
     let nchunks = cmp::max(1, (file_size as f64 / chunk_size as f64).ceil() as u64);
     (0..nchunks)
         .map(move |part_number| {
@@ -454,7 +449,7 @@ impl S3File {
         file_path: String,
         destination_path: Option<Vec<String>>,
         upload_id: Option<UploadId>,
-    ) -> bf::Result<Self> {
+    ) -> Result<Self> {
         let file_path: PathBuf = file_path.into();
 
         let metadata = fs::metadata(file_path.clone())?;
@@ -463,7 +458,7 @@ impl S3File {
         let file_name = file_path
             .file_name()
             .and_then(|name| name.to_str())
-            .ok_or_else(|| bf::ErrorKind::InvalidUnicodePathError(file_path.clone()))?;
+            .ok_or_else(|| Error::invalid_unicode_path(file_path.clone()))?;
 
         Ok(Self {
             upload_id,
@@ -544,7 +539,7 @@ impl S3File {
     }
 
     #[allow(dead_code)]
-    pub fn read_bytes<P: AsRef<Path>>(&self, from_path: P) -> bf::Future<Vec<u8>> {
+    pub fn read_bytes<P: AsRef<Path>>(&self, from_path: P) -> Future<Vec<u8>> {
         let file_path: PathBuf = from_path.as_ref().join(self.file_name.to_owned());
         into_future_trait(future::lazy(move || {
             let f = match fs::File::open(file_path) {
@@ -552,13 +547,13 @@ impl S3File {
                 Err(e) => return future::err(e.into()),
             };
             f.bytes()
-                .collect::<Result<Vec<_>, _>>()
+                .collect::<result::Result<Vec<_>, _>>()
                 .map_err(Into::into)
                 .into_future()
         }))
     }
 
-    pub fn chunks<P: AsRef<Path>>(&self, from_path: P, chunk_size: u64) -> bf::Stream<S3FileChunk> {
+    pub fn chunks<P: AsRef<Path>>(&self, from_path: P, chunk_size: u64) -> Stream<S3FileChunk> {
         let file_path = from_path.as_ref().join(self.file_name.clone());
         match file_chunks(file_path, self.size(), chunk_size) {
             Ok(ch) => into_stream_trait(stream::iter_ok(ch)),

--- a/src/bf/model/upload.rs
+++ b/src/bf/model/upload.rs
@@ -366,7 +366,7 @@ impl FileUpload {
                             .to_str()
                             .map(|dir| dir.to_string())
                             .ok_or_else(|| {
-                                Error::invalid_unicode_path(destination_path.to_path_buf()).into()
+                                Error::invalid_unicode_path(destination_path.to_path_buf())
                             })
                     })
                     .collect::<Result<Vec<String>>>()?;

--- a/src/bf/types.rs
+++ b/src/bf/types.rs
@@ -6,7 +6,7 @@ use futures;
 
 use bf::error;
 
-pub use bf::error::{Error, ErrorKind, Result, ResultExt};
+pub use bf::error::{Error, ErrorKind, Result};
 
 /// A `futures::future::Future` type parameterized by `bf::error::Error`
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
 // Copyright (c) 2018 Blackfynn, Inc. All Rights Reserved.
 
-// `error_chain!` can recurse deeply
-#![recursion_limit = "1024"]
-
 extern crate chrono;
-#[macro_use]
 extern crate failure;
 extern crate failure_derive;
 extern crate futures;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@
 
 extern crate chrono;
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
+extern crate failure_derive;
 extern crate futures;
 extern crate hyper;
 extern crate hyper_tls;
@@ -31,5 +32,5 @@ mod bf;
 // Publicly re-export:
 pub use bf::api::{BFChildren, BFId, BFName, Blackfynn};
 pub use bf::config::{Config, Environment};
-pub use bf::types::{Error, ErrorKind, Future, Result, ResultExt, Stream};
+pub use bf::types::{Error, ErrorKind, Future, Result, Stream};
 pub use bf::{api, error, model};


### PR DESCRIPTION
Since error-chain is no longer supported, we're moving over to the failure crate for error management.