### PR TITLE
AP-603: Add support for new collaborators endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Blackfynn Rust library.
 ## Usage
 ```
 [dependencies]
-blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.11.0" }
+blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.11.1" }
 ```
 
 ## License

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -1543,7 +1543,13 @@ pub mod tests {
         })
         .unwrap();
 
-        assert_eq!(organization_role.role().clone(), "manager".to_string());
+        let organization_role = (
+            organization_role.name().clone(),
+            organization_role.role().clone(),
+        );
+        let expected = ("Blackfynn".to_string(), "manager".to_string());
+
+        assert_eq!(organization_role, expected);
     }
 
     #[test]

--- a/src/bf/api/response/mod.rs
+++ b/src/bf/api/response/mod.rs
@@ -23,7 +23,7 @@ pub use self::account::ApiSession;
 pub use self::channel::Channel;
 pub use self::dataset::{ChangeResponse, CollaboratorCounts, Collaborators, Dataset};
 pub use self::file::{File, Files};
-pub use self::organization::{Organization, Organizations};
+pub use self::organization::{Organization, OrganizationRole, Organizations};
 pub use self::package::Package;
 pub use self::security::{TemporaryCredential, UploadCredential};
 pub use self::team::Team;

--- a/src/bf/api/response/organization.rs
+++ b/src/bf/api/response/organization.rs
@@ -99,10 +99,20 @@ impl IntoIterator for Organizations {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct OrganizationRole {
+    id: String,
+    name: String,
     role: String,
 }
 
 impl OrganizationRole {
+    pub fn id(&self) -> &String {
+        &self.id
+    }
+
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+
     pub fn role(&self) -> &String {
         &self.role
     }

--- a/src/bf/api/response/organization.rs
+++ b/src/bf/api/response/organization.rs
@@ -94,3 +94,16 @@ impl IntoIterator for Organizations {
         self.organizations.into_iter()
     }
 }
+
+/// An organization role.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OrganizationRole {
+    role: String,
+}
+
+impl OrganizationRole {
+    pub fn role(&self) -> &String {
+        &self.role
+    }
+}

--- a/src/bf/model/team.rs
+++ b/src/bf/model/team.rs
@@ -68,6 +68,7 @@ impl From<String> for TeamId {
 pub struct Team {
     id: TeamId,
     name: String,
+    role: Option<String>,
 }
 
 impl Team {
@@ -77,6 +78,10 @@ impl Team {
 
     pub fn name(&self) -> &String {
         &self.name
+    }
+
+    pub fn role(&self) -> Option<&String> {
+        self.role.as_ref()
     }
 }
 

--- a/src/bf/model/user.rs
+++ b/src/bf/model/user.rs
@@ -70,6 +70,7 @@ pub struct User {
     last_name: String,
     email: String,
     preferred_organization: Option<model::OrganizationId>,
+    role: Option<String>,
 }
 
 impl BFId for User {
@@ -98,5 +99,9 @@ impl User {
 
     pub fn preferred_organization(&self) -> Option<&model::OrganizationId> {
         self.preferred_organization.as_ref()
+    }
+
+    pub fn role(&self) -> Option<&String> {
+        self.role.as_ref()
     }
 }


### PR DESCRIPTION
Split out the existing collaborators function to users, teams, and org in order to take advantage of the new endpoints.