### PR TITLE
Track completion of files with a dedicated flag in ProgressUpdate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 edition = "2018"

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -1900,7 +1900,7 @@ pub mod tests {
                                 let p = path.to_path_buf();
                                 if !done.borrow().contains(&p) {
                                     println!("{:?} => {}%", p, update.percent_done());
-                                    if update.completed() {
+                                    if update.percent_done() >= 100.0 {
                                         done.borrow_mut().insert(p);
                                     }
                                 }

--- a/src/bf/api/client/progress.rs
+++ b/src/bf/api/client/progress.rs
@@ -46,6 +46,7 @@ pub struct ProgressUpdate {
     file_path: PathBuf,
     bytes_sent: u64,
     size: u64,
+    done: bool
 }
 
 impl ProgressUpdate {
@@ -55,6 +56,7 @@ impl ProgressUpdate {
         file_path: PathBuf,
         bytes_sent: u64,
         size: u64,
+        done: bool
     ) -> Self {
         Self {
             part_number,
@@ -62,6 +64,7 @@ impl ProgressUpdate {
             file_path,
             bytes_sent,
             size,
+            done
         }
     }
 
@@ -90,6 +93,11 @@ impl ProgressUpdate {
         self.size
     }
 
+    /// Tests if the update represents completion of the file.
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
     /// Returns the upload percentage completed.
     pub fn percent_done(&self) -> f32 {
 
@@ -106,10 +114,5 @@ impl ProgressUpdate {
         }
 
         (self.bytes_sent as f32 / self.size as f32) * 100.0
-    }
-
-    /// Tests if the file completed uploading.
-    pub fn completed(&self) -> bool {
-        self.percent_done() >= 100.0
     }
 }

--- a/src/bf/api/client/s3.rs
+++ b/src/bf/api/client/s3.rs
@@ -251,6 +251,7 @@ where
                                     file_path,
                                     updated_bytes_sent,
                                     file_size,
+                                    false
                                 );
 
                                 let progress = cb.lock().unwrap();
@@ -535,7 +536,7 @@ impl S3Uploader {
             })
             .and_then(move |_| {
                 let update =
-                    ProgressUpdate::new(1, import_id.clone(), file_path, file_size, file_size);
+                    ProgressUpdate::new(1, import_id.clone(), file_path, file_size, file_size, true);
                 cb.on_update(&update);
                 Ok(import_id)
             });


### PR DESCRIPTION
This PR adds an additional flag to the ProgressUpdate struct that tracks when uploading is complete for a given file. Completion is signaled by the completion of polling in the `ChunkedFilePayload` `Stream` implementation.