### PR TITLE
Retry Requests if the rate limit was exceeded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.11.4"
+version = "0.11.5"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Blackfynn Rust library.
 ## Usage
 ```
 [dependencies]
-blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.11.4" }
+blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.11.5" }
 ```
 
 ## License

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -41,7 +41,7 @@ const X_SESSION_ID: &str = "X-SESSION-ID";
 const MAX_RETRIES: usize = 20;
 
 lazy_static! {
-    static ref ALL_METHODS: Vec<hyper::Method> = vec![
+    static ref ALL_METHODS: Vec<Method> = vec![
         Method::GET,
         Method::POST,
         Method::PUT,
@@ -52,10 +52,10 @@ lazy_static! {
         Method::PATCH,
         Method::TRACE,
     ];
-    static ref NON_IDEMPOTENT_METHODS: Vec<hyper::Method> = vec![
+    static ref NON_IDEMPOTENT_METHODS: Vec<Method> = vec![
         Method::POST, Method::DELETE
     ];
-    static ref IDEMPOTENT_METHODS: Vec<hyper::Method> = ALL_METHODS
+    static ref IDEMPOTENT_METHODS: Vec<Method> = ALL_METHODS
         .clone()
         .into_iter()
         .filter(|method| !NON_IDEMPOTENT_METHODS.contains(method))
@@ -63,7 +63,7 @@ lazy_static! {
 
     /// A map of retryable status codes to the list of methods that we
     /// want to retry for those status codes.
-    static ref RETRYABLE_STATUS_CODES: HashMap<StatusCode, Vec<hyper::Method>> = vec![
+    static ref RETRYABLE_STATUS_CODES: HashMap<StatusCode, Vec<Method>> = vec![
         // 4XX
         (StatusCode::TOO_MANY_REQUESTS, ALL_METHODS.clone()),
         // 5XX
@@ -155,46 +155,46 @@ macro_rules! payload {
 
 macro_rules! get {
     ($target:expr, $route:expr) => {
-        $target.request($route, hyper::Method::GET, params!(), payload!())
+        $target.request($route, Method::GET, params!(), payload!())
     };
     ($target:expr, $route:expr, $params:expr) => {
-        $target.request($route, hyper::Method::GET, $params, payload!())
+        $target.request($route, Method::GET, $params, payload!())
     };
 }
 
 macro_rules! post {
     ($target:expr, $route:expr) => {
-        $target.request($route, hyper::Method::POST, params!(), payload!())
+        $target.request($route, Method::POST, params!(), payload!())
     };
     ($target:expr, $route:expr, $params:expr) => {
-        $target.request($route, hyper::Method::POST, $params, payload!())
+        $target.request($route, Method::POST, $params, payload!())
     };
     ($target:expr, $route:expr, $params:expr, $payload:expr) => {
-        $target.request($route, hyper::Method::POST, $params, payload!($payload))
+        $target.request($route, Method::POST, $params, payload!($payload))
     };
 }
 
 macro_rules! put {
     ($target:expr, $route:expr) => {
-        $target.request($route, hyper::Method::PUT, params!(), payload!())
+        $target.request($route, Method::PUT, params!(), payload!())
     };
     ($target:expr, $route:expr, $params:expr) => {
-        $target.request($route, hyper::Method::PUT, $params, payload!())
+        $target.request($route, Method::PUT, $params, payload!())
     };
     ($target:expr, $route:expr, $params:expr, $payload:expr) => {
-        $target.request($route, hyper::Method::PUT, $params, payload!($payload))
+        $target.request($route, Method::PUT, $params, payload!($payload))
     };
 }
 
 macro_rules! delete {
     ($target:expr, $route:expr) => {
-        $target.request($route, hyper::Method::DELETE, params!(), payload!())
+        $target.request($route, Method::DELETE, params!(), payload!())
     };
     ($target:expr, $route:expr, $params:expr) => {
-        $target.request($route, hyper::Method::DELETE, $params, payload!())
+        $target.request($route, Method::DELETE, $params, payload!())
     };
     ($target:expr, $route:expr, $params:expr, $payload:expr) => {
-        $target.request($route, hyper::Method::DELETE, $params, payload!($payload))
+        $target.request($route, Method::DELETE, $params, payload!($payload))
     };
 }
 
@@ -244,7 +244,7 @@ impl Blackfynn {
     fn request<I, P, Q, S>(
         &self,
         route: S,
-        method: hyper::Method,
+        method: Method,
         params: I,
         payload: Option<&P>,
     ) -> Future<Q>
@@ -303,7 +303,7 @@ impl Blackfynn {
     fn request_with_body<I, Q, S>(
         &self,
         route: S,
-        method: hyper::Method,
+        method: Method,
         params: I,
         body: Vec<u8>,
         additional_headers: Vec<(HeaderName, HeaderValue)>,
@@ -324,7 +324,7 @@ impl Blackfynn {
                 bf: Blackfynn,
                 route: String,
                 params: Vec<RequestParam>,
-                method: hyper::Method,
+                method: Method,
                 body: Vec<u8>,
                 additional_headers: Vec<(HeaderName, HeaderValue)>,
                 try_num: usize,
@@ -431,7 +431,7 @@ impl Blackfynn {
         &self,
         route: String,
         params: Vec<RequestParam>,
-        method: hyper::Method,
+        method: Method,
         body: hyper::Body,
         additional_headers: Vec<(HeaderName, HeaderValue)>,
     ) -> Future<(StatusCode, hyper::Chunk)> {
@@ -1036,7 +1036,7 @@ impl Blackfynn {
                                     organization_id,
                                     import_id
                                 ),
-                                hyper::Method::POST,
+                                Method::POST,
                                 params!(
                                     "filename" => file.file_name().to_string(),
                                     "multipartId" => multipart_upload_id.to_string(),

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -357,10 +357,10 @@ impl Blackfynn {
         into_future_trait(json)
     }
 
-    /// Make a single request to the platform. This function is meant
-    /// to only be used by `request` and `request_with_body` when for
-    /// when retrying requests, and those functions should be used
-    /// instead of this one to send requests to the platform.
+    /// Make a single request to the platform. This function is used
+    /// by `request` and `request_with_body`, so those functions
+    /// should be preferred over this one for making requests to the
+    /// platform.
     ///
     /// # Arguments
     ///

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -75,9 +75,12 @@ lazy_static! {
 
 /// Given the number of the current attempt, calculate the delay (in
 /// milliseconds) for how long we should wait until the next retry
-/// using an exponential backoff algorithm
+///
+/// # Arguments
+///
+/// * `try_num` - The number of this attempt, indexed at 0
 fn retry_delay(try_num: usize) -> u64 {
-    500 * 2_u64.pow(try_num as u32 - 1)
+    500 * try_num as u64
 }
 
 struct BlackFynnImpl {

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -61,6 +61,8 @@ lazy_static! {
         .filter(|method| !NON_IDEMPOTENT_METHODS.contains(method))
         .collect();
 
+    /// A map of retryable status codes to the list of methods that we
+    /// want to retry for those status codes.
     static ref RETRYABLE_STATUS_CODES: HashMap<StatusCode, Vec<hyper::Method>> = vec![
         // 4XX
         (StatusCode::TOO_MANY_REQUESTS, ALL_METHODS.clone()),

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -181,6 +181,19 @@ impl Blackfynn {
         self.inner.lock().unwrap().config.env().url().clone()
     }
 
+    /// Make a request to the given route using the given json payload
+    /// as a request body. This function will automatically retry if
+    /// it receives a 429 response (rate limit exceeded) from the
+    /// blackfynn API.
+    ///
+    /// # Arguments
+    ///
+    /// * `route` - The target Blackfynn API route
+    /// * `method` - The HTTP method
+    /// * `params` - Query params to include in the request
+    /// * `payload` - A json-serializable payload to send to the platform
+    ///       along with the request
+    /// ```
     fn request<I, P, Q, S>(
         &self,
         route: S,
@@ -219,6 +232,22 @@ impl Blackfynn {
         }
     }
 
+    /// Make a request to the given route using the given byte payload
+    /// as a request body. This is a more low-level function than the
+    /// above `request` function, as it allows you to send raw bytes
+    /// to the platform. This function is specifically useful when
+    /// uploading files, for example.
+    ///
+    /// # Arguments
+    ///
+    /// * `route` - The target Blackfynn API route
+    /// * `method` - The HTTP method
+    /// * `params` - Query params to include in the request
+    /// * `body` - A byte array payload
+    /// * `additional_headers` - Additional headers to include
+    /// * `retry_on_failure` - If true, this function will retry when it
+    ///       receives a 429 response.
+    /// ```
     fn request_with_body<I, Q, S>(
         &self,
         route: S,
@@ -317,6 +346,19 @@ impl Blackfynn {
         into_future_trait(json)
     }
 
+    /// Make a single request to the platform. This function is meant
+    /// to only be used by `request` and `request_with_body` when for
+    /// when retrying requests, and those functions should be used
+    /// instead of this one to send requests to the platform.
+    ///
+    /// # Arguments
+    ///
+    /// * `route` - The target Blackfynn API route
+    /// * `params` - Query params to include in the request
+    /// * `method` - The HTTP method
+    /// * `body` - A byte array payload
+    /// * `additional_headers` - Additional headers to include
+    /// ```
     fn single_request(
         &self,
         route: String,

--- a/src/bf/error.rs
+++ b/src/bf/error.rs
@@ -95,6 +95,12 @@ impl fmt::Display for Error {
     }
 }
 
+impl Clone for Error {
+    fn clone(&self) -> Self {
+        self.kind().clone().into()
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Fail)]
 pub enum ErrorKind {
     #[fail(display = "api error: {} {}", status_code, message)]


### PR DESCRIPTION
This library is running into failures due to our new rate limit. This PR adds an automatic retry to our request functions for when the rate limit is exceeded.