### PR TITLE
Index chunks for empty files at 0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Blackfynn Rust library.
 ## Usage
 ```
 [dependencies]
-blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.12.0" }
+blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.12.2" }
 ```
 
 ## License

--- a/src/bf/api/request/chunked_http.rs
+++ b/src/bf/api/request/chunked_http.rs
@@ -145,7 +145,7 @@ impl Stream for ChunkedFilePayload {
                     FileChunk {
                         bytes: vec![],
                         checksum: Checksum(String::from(EMPTY_SHA256_HASH)),
-                        chunk_number: self.parts_sent,
+                        chunk_number: 0,
                     },
                     self.build_progress_update(true),
                 ))))


### PR DESCRIPTION
All other chunked uploads are indexed at 0, we need empty files to behave the same way.