### PR TITLE
Bubble up Permissions Errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blackfynn"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Blackfynn <https://github.com/Blackfynn/blackfynn-rust>"]
 publish = false
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Blackfynn Rust library.
 ## Usage
 ```
 [dependencies]
-blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.12.2" }
+blackfynn = { git = "https://github.com/Blackfynn/blackfynn-rust.git", tag = "v0.12.3" }
 ```
 
 ## License

--- a/src/bf/api/client/mod.rs
+++ b/src/bf/api/client/mod.rs
@@ -364,11 +364,9 @@ impl Blackfynn {
                                 retry_state.try_num += 1;
 
                                 if retry_state.try_num > MAX_RETRIES {
-                                    into_future_trait(future::err(Error::retries_exceeded(
-                                        Error::api_error(
-                                            status_code,
-                                            String::from_utf8_lossy(&body),
-                                        ),
+                                    into_future_trait(future::err(Error::api_error(
+                                        status_code,
+                                        String::from_utf8_lossy(&body),
                                     )))
                                 } else {
                                     let delay = retry_delay(retry_state.try_num);
@@ -1267,7 +1265,7 @@ impl Blackfynn {
                         // MAX_RETRIES exceeded, bubble up the error
                         _ => {
                             error!("Retries exceeded during upload. Bubbling up error {error}", error = err);
-                            into_future_trait(future::err(Error::retries_exceeded(err)))
+                            into_future_trait(future::err(err))
                         }
                     }
                 })

--- a/src/bf/error.rs
+++ b/src/bf/error.rs
@@ -79,13 +79,6 @@ impl Error {
     pub fn invalid_unicode_path(path: PathBuf) -> Error {
         ErrorKind::InvalidUnicodePath { path }.into()
     }
-
-    pub fn retries_exceeded(last_error: Error) -> Error {
-        ErrorKind::RetriesExceeded {
-            last_error: format!("{}", last_error),
-        }
-        .into()
-    }
 }
 
 impl Fail for Error {
@@ -150,9 +143,6 @@ pub enum ErrorKind {
 
     #[fail(display = "no organization set")]
     NoOrganizationSet,
-
-    #[fail(display = "retries exceeded: last error: {}", last_error)]
-    RetriesExceeded { last_error: String },
 
     #[fail(display = "missing upload id")]
     S3MissingUploadId,

--- a/src/bf/error.rs
+++ b/src/bf/error.rs
@@ -79,6 +79,13 @@ impl Error {
     pub fn invalid_unicode_path(path: PathBuf) -> Error {
         ErrorKind::InvalidUnicodePath { path }.into()
     }
+
+    pub fn retries_exceeded(last_error: Error) -> Error {
+        ErrorKind::RetriesExceeded {
+            last_error: format!("{}", last_error),
+        }
+        .into()
+    }
 }
 
 impl Fail for Error {
@@ -144,8 +151,8 @@ pub enum ErrorKind {
     #[fail(display = "no organization set")]
     NoOrganizationSet,
 
-    #[fail(display = "retries exceeded")]
-    RetriesExceeded,
+    #[fail(display = "retries exceeded: last error: {}", last_error)]
+    RetriesExceeded { last_error: String },
 
     #[fail(display = "missing upload id")]
     S3MissingUploadId,


### PR DESCRIPTION
When the library receives 401/403 errors from the platform, these errors cannot be resolved automatically by retrying the request. Instead, the library should bubble these errors directly to the caller so that they can refresh their token.